### PR TITLE
fix: release without committing to default branch

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -3,8 +3,7 @@
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
     ["@semantic-release/npm", { "npmPublish": true }],
-    "@semantic-release/changelog",
-    "@semantic-release/git"
+    "@semantic-release/changelog"
   ],
   "branches": ["main"]
 }


### PR DESCRIPTION
Committing to the `main` branch is restricted to favor PRs. This also prevents the CI from committing a changelog file. As the changelog is included in the release note, the plugin has completely been removed.