### PR TITLE
test: wait for useFind execution before emitting removed event

### DIFF
--- a/test/useFind.test.ts
+++ b/test/useFind.test.ts
@@ -405,7 +405,7 @@ describe('Find composition', () => {
       expect(findComposition && findComposition.data.value.length).toStrictEqual(0);
     });
 
-    it('should listen to "remove" events', () => {
+    it('should listen to "remove" events', async () => {
       expect.assertions(2);
 
       // given
@@ -424,6 +424,7 @@ describe('Find composition', () => {
       mountComposition(() => {
         findComposition = useFind('testModels');
       });
+      await nextTick();
 
       // when
       emitter.emit('removed', testModel);


### PR DESCRIPTION
Actually loads `testModel` before removing and thus executes the filter function resulting in full test coverage.